### PR TITLE
Fix test runner with special characters in names

### DIFF
--- a/src/testParser.ts
+++ b/src/testParser.ts
@@ -76,3 +76,13 @@ export function parseTestFile(content: string): ParsedTest[] {
 export function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+/**
+ * Escapes a string for safe use as a shell argument.
+ * Uses single quotes and escapes any embedded single quotes.
+ */
+export function escapeShellArg(text: string): string {
+  // Wrap in single quotes and escape any embedded single quotes
+  // by ending the single-quoted string, adding an escaped single quote, and restarting
+  return `'${text.replace(/'/g, "'\\''")}'`;
+}

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { spawn } from 'child_process';
 import { getConfig } from './config';
-import { escapeRegExp } from './testParser';
+import { escapeRegExp, escapeShellArg } from './testParser';
 
 export interface TestResult {
   passed: boolean;
@@ -24,18 +24,19 @@ export async function runLabTest(
     return;
   }
 
-  const workspaceFolder = vscode.workspace.getWorkspaceFolder(testItem.uri!);
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(testItem.uri);
   const cwd = workspaceFolder?.uri.fsPath || path.dirname(testFilePath);
 
   const testName = testItem.label;
   const escapedName = escapeRegExp(testName);
+  const shellSafeName = escapeShellArg(escapedName);
 
   const args = [
     'lab',
     '-m', config.timeout.toString(),
     '-v',
     '-r', 'console',
-    '-g', escapedName,
+    '-g', shellSafeName,
     testFilePath,
   ];
 

--- a/test/testParser.test.ts
+++ b/test/testParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseTestFile, escapeRegExp } from '../src/testParser';
+import { parseTestFile, escapeRegExp, escapeShellArg } from '../src/testParser';
 
 describe('testParser', () => {
   describe('parseTestFile', () => {
@@ -167,6 +167,47 @@ describe('testParser', () => {
       expect(escapeRegExp('test.name (with) [brackets]')).toBe(
         'test\\.name \\(with\\) \\[brackets\\]'
       );
+    });
+  });
+
+  describe('escapeShellArg', () => {
+    it('should wrap simple strings in single quotes', () => {
+      expect(escapeShellArg('simple')).toBe("'simple'");
+    });
+
+    it('should preserve spaces within quotes', () => {
+      expect(escapeShellArg('test with spaces')).toBe("'test with spaces'");
+    });
+
+    it('should handle strings with parentheses', () => {
+      expect(escapeShellArg('test (with parens)')).toBe("'test (with parens)'");
+    });
+
+    it('should escape embedded single quotes', () => {
+      expect(escapeShellArg("it's a test")).toBe("'it'\\''s a test'");
+    });
+
+    it('should handle multiple single quotes', () => {
+      expect(escapeShellArg("don't won't can't")).toBe(
+        "'don'\\''t won'\\''t can'\\''t'"
+      );
+    });
+
+    it('should handle empty strings', () => {
+      expect(escapeShellArg('')).toBe("''");
+    });
+
+    it('should handle complex test names with special chars', () => {
+      const testName = 'returns cost for model and token counts (for dedicated provider)';
+      const escaped = escapeShellArg(testName);
+      expect(escaped).toBe("'returns cost for model and token counts (for dedicated provider)'");
+    });
+
+    it('should handle test names with regex-escaped characters', () => {
+      // After escapeRegExp, the string might have backslashes
+      const regexEscaped = escapeRegExp('test.name (with) [brackets]');
+      const shellEscaped = escapeShellArg(regexEscaped);
+      expect(shellEscaped).toBe("'test\\.name \\(with\\) \\[brackets\\]'");
     });
   });
 });


### PR DESCRIPTION
When running tests with names containing spaces and special characters (e.g., "returns cost for model and token counts (for dedicated provider)"), the test name was being split into multiple arguments because spawn() was used with shell: true without proper quoting.

Added escapeShellArg() function that wraps arguments in single quotes and escapes embedded single quotes, ensuring the full test name is passed as a single argument to the -g flag.