### PR TITLE
Add TypeScript support to parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "2.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "acorn": "^8.11.0",
-        "acorn-walk": "^8.3.0"
+        "@typescript-eslint/typescript-estree": "^6.13.0"
       },
       "devDependencies": {
         "@types/node": "^20.10.0",
@@ -873,7 +872,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -887,7 +885,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -897,7 +894,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1417,7 +1413,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
       "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1431,7 +1426,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
       "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/types": "6.21.0",
@@ -1486,7 +1480,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
       "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "6.21.0",
@@ -1868,6 +1861,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -1890,6 +1884,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -1959,7 +1954,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1997,7 +1991,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -2046,7 +2039,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2056,7 +2048,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2387,7 +2378,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2527,7 +2517,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
@@ -2847,7 +2836,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3089,7 +3077,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3106,7 +3093,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3133,7 +3119,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3166,7 +3151,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3420,7 +3404,6 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
@@ -3639,7 +3622,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -3719,7 +3701,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3729,7 +3710,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3761,7 +3741,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4246,7 +4225,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -4256,7 +4234,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -4333,7 +4310,6 @@
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
       "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -4388,7 +4364,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -4724,7 +4699,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4765,7 +4739,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4930,7 +4903,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5025,7 +4997,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -5111,7 +5082,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5170,7 +5140,6 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5351,7 +5320,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5576,7 +5544,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -5589,7 +5556,6 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
       "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -5681,7 +5647,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "vitest": "^1.0.0"
   },
   "dependencies": {
-    "acorn": "^8.11.0",
-    "acorn-walk": "^8.3.0"
+    "@typescript-eslint/typescript-estree": "^6.13.0"
   }
 }

--- a/src/testParser.ts
+++ b/src/testParser.ts
@@ -1,5 +1,4 @@
-import * as acorn from 'acorn';
-import * as walk from 'acorn-walk';
+import { parse, simpleTraverse, AST_NODE_TYPES, TSESTree } from '@typescript-eslint/typescript-estree';
 import * as vscode from 'vscode';
 
 export interface ParsedTest {
@@ -9,60 +8,54 @@ export interface ParsedTest {
   children: ParsedTest[];
 }
 
-interface AcornNode {
-  type: string;
-  loc?: acorn.SourceLocation;
-  callee?: AcornNode;
-  name?: string;
-  arguments?: AcornNode[];
-  value?: string | number | boolean | null | RegExp | bigint;
-  raw?: string;
-}
-
 const TEST_FUNCTIONS = new Set(['describe', 'it', 'experiment', 'test']);
 
 export function parseTestFile(content: string): ParsedTest[] {
   const tests: ParsedTest[] = [];
 
   try {
-    const ast = acorn.parse(content, {
-      ecmaVersion: 'latest',
-      sourceType: 'module',
-      locations: true,
-      allowHashBang: true,
+    const ast = parse(content, {
+      loc: true,
+      range: true,
+      jsx: true,
     });
 
-    walk.simple(ast, {
-      CallExpression(node: acorn.Node) {
-        const callNode = node as unknown as AcornNode;
-        if (
-          callNode.callee?.type === 'Identifier' &&
-          callNode.callee.name &&
-          TEST_FUNCTIONS.has(callNode.callee.name) &&
-          callNode.arguments &&
-          callNode.arguments.length >= 2 &&
-          (callNode.arguments[0].type === 'Literal' || callNode.arguments[0].type === 'TemplateLiteral') &&
-          callNode.loc
-        ) {
-          const firstArg = callNode.arguments[0];
-          const testName = (typeof firstArg.value === 'string' ? firstArg.value : null) ||
-            (firstArg.raw ? firstArg.raw.slice(1, -1) : 'unnamed test');
+    simpleTraverse(ast, {
+      enter(node) {
+        if (node.type === AST_NODE_TYPES.CallExpression) {
+          const callNode = node;
+          if (
+            callNode.callee.type === AST_NODE_TYPES.Identifier &&
+            TEST_FUNCTIONS.has(callNode.callee.name) &&
+            callNode.arguments.length >= 2 &&
+            (callNode.arguments[0].type === AST_NODE_TYPES.Literal || callNode.arguments[0].type === AST_NODE_TYPES.TemplateLiteral) &&
+            callNode.loc
+          ) {
+            const firstArg = callNode.arguments[0];
+            let testName = 'unnamed test';
 
-          const range = new vscode.Range(
-            callNode.loc.start.line - 1,
-            callNode.loc.start.column,
-            callNode.loc.end.line - 1,
-            callNode.loc.end.column
-          );
+            if (firstArg.type === AST_NODE_TYPES.Literal && typeof (firstArg as TSESTree.Literal).value === 'string') {
+              testName = (firstArg as TSESTree.Literal).value as string;
+            } else if (firstArg.type === AST_NODE_TYPES.TemplateLiteral && (firstArg).quasis.length > 0) {
+              testName = (firstArg).quasis.map((q) => q.value.cooked || q.value.raw).join('');
+            }
 
-          const testType = callNode.callee.name as ParsedTest['type'];
+            const range = new vscode.Range(
+              callNode.loc.start.line - 1,
+              callNode.loc.start.column,
+              callNode.loc.end.line - 1,
+              callNode.loc.end.column
+            );
 
-          tests.push({
-            name: testName,
-            type: testType,
-            range,
-            children: [],
-          });
+            const testType = callNode.callee.name as ParsedTest['type'];
+
+            tests.push({
+              name: testName,
+              type: testType,
+              range,
+              children: [],
+            });
+          }
         }
       },
     });

--- a/test/testParser.test.ts
+++ b/test/testParser.test.ts
@@ -138,6 +138,130 @@ describe('testParser', () => {
       expect(tests).toHaveLength(1);
       expect(tests[0].name).toBe('test with options');
     });
+
+    it('should parse TypeScript files with type annotations', () => {
+      const code = `
+        interface User {
+          name: string;
+          age: number;
+        }
+
+        const createUser = (name: string, age: number): User => ({ name, age });
+
+        describe('User creation', () => {
+          it('should create a user with valid data', () => {
+            const user: User = createUser('test', 25);
+            expect(user.name).toBe('test');
+          });
+        });
+      `;
+
+      const tests = parseTestFile(code);
+
+      expect(tests).toHaveLength(2);
+      const names = tests.map((t) => t.name);
+      expect(names).toContain('User creation');
+      expect(names).toContain('should create a user with valid data');
+    });
+
+    it('should parse TypeScript files with generics', () => {
+      const code = `
+        function identity<T>(value: T): T {
+          return value;
+        }
+
+        it('should handle generic functions', () => {
+          const result = identity<string>('test');
+          expect(result).toBe('test');
+        });
+      `;
+
+      const tests = parseTestFile(code);
+
+      expect(tests).toHaveLength(1);
+      expect(tests[0].name).toBe('should handle generic functions');
+    });
+
+    it('should parse TypeScript files with type aliases and unions', () => {
+      const code = `
+        type Status = 'pending' | 'success' | 'error';
+        type Result<T> = { status: Status; data: T | null };
+
+        describe('Result handling', () => {
+          it('should handle success result', () => {
+            const result: Result<string> = { status: 'success', data: 'test' };
+            expect(result.status).toBe('success');
+          });
+        });
+      `;
+
+      const tests = parseTestFile(code);
+
+      expect(tests).toHaveLength(2);
+      expect(tests.map((t) => t.name)).toContain('should handle success result');
+    });
+
+    it('should parse TypeScript files with enums', () => {
+      const code = `
+        enum Direction {
+          Up = 'UP',
+          Down = 'DOWN',
+        }
+
+        it('should use enum values', () => {
+          const dir: Direction = Direction.Up;
+          expect(dir).toBe('UP');
+        });
+      `;
+
+      const tests = parseTestFile(code);
+
+      expect(tests).toHaveLength(1);
+      expect(tests[0].name).toBe('should use enum values');
+    });
+
+    it('should parse TypeScript files with class syntax', () => {
+      const code = `
+        class Calculator {
+          private value: number = 0;
+
+          public add(n: number): this {
+            this.value += n;
+            return this;
+          }
+
+          public getValue(): number {
+            return this.value;
+          }
+        }
+
+        describe('Calculator', () => {
+          it('should add numbers', () => {
+            const calc = new Calculator();
+            expect(calc.add(5).getValue()).toBe(5);
+          });
+        });
+      `;
+
+      const tests = parseTestFile(code);
+
+      expect(tests).toHaveLength(2);
+      expect(tests.map((t) => t.name)).toContain('should add numbers');
+    });
+
+    it('should parse TypeScript files with as assertions', () => {
+      const code = `
+        it('should handle type assertions', () => {
+          const value = JSON.parse('{"name": "test"}') as { name: string };
+          expect(value.name).toBe('test');
+        });
+      `;
+
+      const tests = parseTestFile(code);
+
+      expect(tests).toHaveLength(1);
+      expect(tests[0].name).toBe('should handle type assertions');
+    });
   });
 
   describe('escapeRegExp', () => {


### PR DESCRIPTION
Acorn only parses JavaScript, causing test discovery to silently fail on TypeScript files with type annotations. This replaces Acorn with @typescript-eslint/typescript-estree which can parse both JavaScript and TypeScript, enabling proper test discovery in .ts files.