### PR TITLE
Fix release workflow version conflict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump version, publish, and push
+      - name: Bump version and push
         run: |
-          npx @vscode/vsce publish -p ${{ secrets.VSCE_PAT }} patch
-          # Amend the version commit to add [skip ci] to prevent infinite loop
-          git commit --amend -m "$(git log -1 --format=%s) [skip ci]"
+          # Bump patch version - this creates a commit
+          npm version patch -m "%s [skip ci]"
           git push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to VS Code Marketplace
+        run: npx @vscode/vsce publish -p ${{ secrets.VSCE_PAT }}
 
       # - name: Publish to Open VSX Registry
       #   run: npx ovsx publish -p ${{ secrets.OVSX_PAT }}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-lab-test-runner",
   "displayName": "Vscode hapi/lab Test Runner",
   "description": "Run and debug hapijs/lab tests with VS Code's native Test Explorer",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "license": "BSD-3-Clause",
   "icon": "images/icon.png",
   "galleryBanner": {


### PR DESCRIPTION
- Update package.json to 5.0.9 to sync with marketplace
- Change workflow to bump version and push BEFORE publishing
  - This ensures if publish fails, we can retry without conflict
  - Uses npm version patch instead of vsce publish patch
- Add [skip ci] to version commit message to prevent infinite loop