### PR TITLE
Fix command formatting with special characters

### DIFF
--- a/src/testParser.ts
+++ b/src/testParser.ts
@@ -108,18 +108,3 @@ export function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-/**
- * Escapes a string for safe use as a shell argument.
- *
- * Wraps the string in single quotes and escapes any embedded single quotes
- * by ending the quoted section, adding an escaped quote, and restarting.
- * This prevents shell injection when passing test names to the lab CLI.
- *
- * @param text - The string to escape for shell usage
- * @returns The safely escaped shell argument
- */
-export function escapeShellArg(text: string): string {
-  // Wrap in single quotes and escape any embedded single quotes
-  // by ending the single-quoted string, adding an escaped single quote, and restarting
-  return `'${text.replace(/'/g, "'\\''")}'`;
-}

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { spawn } from 'child_process';
 import { getConfig } from './config';
-import { escapeRegExp, escapeShellArg } from './testParser';
+import { escapeRegExp } from './testParser';
 
 /**
  * Result of a single test execution.
@@ -104,7 +104,6 @@ async function runPretestScript(
   return new Promise<boolean>((resolve) => {
     const proc = spawn('npm', ['run', 'pretest'], {
       cwd,
-      shell: true,
       env: { ...process.env, FORCE_COLOR: '1' },
     });
 
@@ -171,7 +170,6 @@ export async function runLabTest(
 
   const testName = testItem.label;
   const escapedName = escapeRegExp(testName);
-  const shellSafeName = escapeShellArg(escapedName);
 
   let command: string;
   let args: string[];
@@ -182,7 +180,7 @@ export async function runLabTest(
     // Run via npm test, passing lab args after --
     // The test script chain (e.g., wolo -> lab) handles timeout/reporter
     command = 'npm';
-    args = ['test', '--', '-g', shellSafeName, testFilePath];
+    args = ['test', '--', '-g', escapedName, testFilePath];
   } else {
     // Run lab directly via npx
     command = 'npx';
@@ -191,7 +189,7 @@ export async function runLabTest(
       '-m', config.timeout.toString(),
       '-v',
       '-r', 'console',
-      '-g', shellSafeName,
+      '-g', escapedName,
       testFilePath,
     ];
   }
@@ -205,7 +203,6 @@ export async function runLabTest(
 
     const proc = spawn(command, args, {
       cwd,
-      shell: true,
       env: { ...process.env, FORCE_COLOR: '1' },
     });
 

--- a/test/testParser.test.ts
+++ b/test/testParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseTestFile, escapeRegExp, escapeShellArg } from '../src/testParser';
+import { parseTestFile, escapeRegExp } from '../src/testParser';
 
 describe('testParser', () => {
   describe('parseTestFile', () => {
@@ -294,44 +294,4 @@ describe('testParser', () => {
     });
   });
 
-  describe('escapeShellArg', () => {
-    it('should wrap simple strings in single quotes', () => {
-      expect(escapeShellArg('simple')).toBe("'simple'");
-    });
-
-    it('should preserve spaces within quotes', () => {
-      expect(escapeShellArg('test with spaces')).toBe("'test with spaces'");
-    });
-
-    it('should handle strings with parentheses', () => {
-      expect(escapeShellArg('test (with parens)')).toBe("'test (with parens)'");
-    });
-
-    it('should escape embedded single quotes', () => {
-      expect(escapeShellArg("it's a test")).toBe("'it'\\''s a test'");
-    });
-
-    it('should handle multiple single quotes', () => {
-      expect(escapeShellArg("don't won't can't")).toBe(
-        "'don'\\''t won'\\''t can'\\''t'"
-      );
-    });
-
-    it('should handle empty strings', () => {
-      expect(escapeShellArg('')).toBe("''");
-    });
-
-    it('should handle complex test names with special chars', () => {
-      const testName = 'returns cost for model and token counts (for dedicated provider)';
-      const escaped = escapeShellArg(testName);
-      expect(escaped).toBe("'returns cost for model and token counts (for dedicated provider)'");
-    });
-
-    it('should handle test names with regex-escaped characters', () => {
-      // After escapeRegExp, the string might have backslashes
-      const regexEscaped = escapeRegExp('test.name (with) [brackets]');
-      const shellEscaped = escapeShellArg(regexEscaped);
-      expect(shellEscaped).toBe("'test\\.name \\(with\\) \\[brackets\\]'");
-    });
-  });
 });


### PR DESCRIPTION
Remove shell: true from spawn() calls and the escapeShellArg function. When using spawn with an args array without shell mode, arguments are passed directly to the process - spaces and special characters in test names are preserved correctly without needing manual shell escaping. The regex escaping (escapeRegExp) is kept for the lab -g flag which uses regex matching.