### PR TITLE
Make test pattern matching more robust

### DIFF
--- a/src/testParser.ts
+++ b/src/testParser.ts
@@ -96,28 +96,79 @@ export function parseTestFile(content: string): ParsedTest[] {
 }
 
 /**
+ * Characters that are safe to use literally in both regex patterns and shell commands.
+ * These characters:
+ * - Don't have special meaning in regex
+ * - Don't have special meaning in bash/sh shells
+ * - Don't cause word splitting or glob expansion
+ */
+const SAFE_PATTERN_CHARS = /^[a-zA-Z0-9_-]$/;
+
+/**
+ * Builds a robust grep pattern for matching a test name.
+ *
+ * This function creates a regex pattern that:
+ * 1. Matches the test name when used with lab's -g (grep) flag
+ * 2. Survives shell interpretation (including multiple layers like npm -> wolo -> lab)
+ * 3. Avoids shell injection or unexpected behavior
+ *
+ * Strategy: Only use characters that are "safe" in both regex and shell contexts.
+ * Any character that might cause issues is replaced with '.' which matches any
+ * single character in regex and is harmless in shells.
+ *
+ * Trade-off: This slightly reduces pattern precision (e.g., "test name" pattern
+ * would also match "testXname"), but test names are typically unique enough that
+ * this rarely causes false matches. The pattern maintains the same length as the
+ * input, so each '.' corresponds to exactly one character position.
+ *
+ * Characters handled:
+ * - Regex specials: . * + ? ^ $ { } ( ) [ ] | \
+ * - Shell specials: space $ ` ' " ; | & < > ! ~ # * ? ( ) { } [ ] \
+ * - Whitespace: tabs, carriage returns
+ * - Unicode: any non-ASCII characters (including emoji surrogate pairs)
+ *
+ * Note: Newlines in test names are replaced with '.' but this won't match properly
+ * since regex '.' doesn't match newlines by default. Test names with literal newlines
+ * are extremely rare in practice.
+ *
+ * @param testName - The test name to convert to a pattern
+ * @returns A regex pattern safe for shell and lab's -g flag
+ */
+export function buildTestPattern(testName: string): string {
+  let pattern = '';
+
+  // Use index-based iteration to handle UTF-16 code units properly
+  // This ensures the pattern length matches the string's .length property,
+  // which is important for regex matching (since JS regex operates on code units)
+  for (let i = 0; i < testName.length; i++) {
+    const char = testName[i];
+    if (SAFE_PATTERN_CHARS.test(char)) {
+      // Alphanumeric, underscore, hyphen - safe to use literally
+      pattern += char;
+    } else {
+      // Everything else becomes '.' to match any single character
+      // This handles: spaces, shell specials, regex specials, unicode, etc.
+      pattern += '.';
+    }
+  }
+
+  return pattern;
+}
+
+/**
+ * @deprecated Use buildTestPattern instead. Kept for backward compatibility.
+ *
  * Escapes special regex characters in a string.
- *
- * Used to convert test names into safe regex patterns for the lab `-g` (grep) flag,
- * which filters tests by name using regex matching.
- *
- * @param text - The string to escape
- * @returns The string with all regex special characters escaped
+ * Used to convert test names into safe regex patterns for the lab `-g` (grep) flag.
  */
 export function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**
+ * @deprecated Use buildTestPattern instead. Kept for backward compatibility.
+ *
  * Escapes a string for safe use as a grep pattern across multiple shell layers.
- *
- * When test names pass through multiple shell layers (npm -> wolo -> npm -> lab),
- * traditional quoting gets stripped at each level. Instead, we replace spaces
- * with `.` (regex "any character") which matches the original space character
- * but doesn't require shell quoting to survive word-splitting.
- *
- * @param text - The regex-escaped string to make shell-safe
- * @returns The pattern with spaces replaced by regex dots
  */
 export function escapeShellArg(text: string): string {
   return text.replace(/ /g, '.');

--- a/src/testRunner.ts
+++ b/src/testRunner.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { spawn } from 'child_process';
 import { getConfig } from './config';
-import { escapeRegExp, escapeShellArg } from './testParser';
+import { buildTestPattern } from './testParser';
 
 /**
  * Result of a single test execution.
@@ -169,7 +169,8 @@ export async function runLabTest(
   const cwd = workspaceFolder?.uri.fsPath || path.dirname(testFilePath);
 
   const testName = testItem.label;
-  const escapedName = escapeRegExp(testName);
+  // Build a robust pattern that works in both shell and non-shell contexts
+  const pattern = buildTestPattern(testName);
 
   let command: string;
   let args: string[];
@@ -180,9 +181,10 @@ export async function runLabTest(
   if (useNpmTest) {
     // Run via npm test, passing lab args after --
     // The test script chain (e.g., wolo -> lab) handles timeout/reporter
-    // Need shell: true and escapeShellArg because npm passes -- args through shell
+    // Need shell: true for npm to properly handle the -- separator
+    // The pattern is already safe for shell interpretation
     command = 'npm';
-    args = ['test', '--', '-g', escapeShellArg(escapedName), testFilePath];
+    args = ['test', '--', '-g', pattern, testFilePath];
     useShell = true;
   } else {
     // Run lab directly via npx
@@ -193,7 +195,7 @@ export async function runLabTest(
       '-m', config.timeout.toString(),
       '-v',
       '-r', 'console',
-      '-g', escapedName,
+      '-g', pattern,
       testFilePath,
     ];
   }

--- a/test/testParser.test.ts
+++ b/test/testParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseTestFile, escapeRegExp, escapeShellArg } from '../src/testParser';
+import { parseTestFile, escapeRegExp, escapeShellArg, buildTestPattern } from '../src/testParser';
 
 describe('testParser', () => {
   describe('parseTestFile', () => {
@@ -294,7 +294,7 @@ describe('testParser', () => {
     });
   });
 
-  describe('escapeShellArg', () => {
+  describe('escapeShellArg (deprecated)', () => {
     it('should leave simple strings without spaces unchanged', () => {
       expect(escapeShellArg('test')).toBe('test');
     });
@@ -332,6 +332,527 @@ describe('testParser', () => {
       // will match 'exports TEST_CONFIG for use by other repos' since . matches any char
       const regex = new RegExp(escaped);
       expect(regex.test(testName)).toBe(true);
+    });
+  });
+
+  describe('buildTestPattern', () => {
+    // ===========================================
+    // BASIC CASES
+    // ===========================================
+    describe('basic cases', () => {
+      it('should handle empty string', () => {
+        expect(buildTestPattern('')).toBe('');
+      });
+
+      it('should preserve simple alphanumeric names', () => {
+        expect(buildTestPattern('test')).toBe('test');
+        expect(buildTestPattern('myTest123')).toBe('myTest123');
+        expect(buildTestPattern('TEST')).toBe('TEST');
+      });
+
+      it('should preserve underscores', () => {
+        expect(buildTestPattern('test_name')).toBe('test_name');
+        expect(buildTestPattern('__private__')).toBe('__private__');
+      });
+
+      it('should preserve hyphens', () => {
+        expect(buildTestPattern('test-name')).toBe('test-name');
+        expect(buildTestPattern('kebab-case-name')).toBe('kebab-case-name');
+      });
+
+      it('should preserve mixed safe characters', () => {
+        expect(buildTestPattern('test_name-123')).toBe('test_name-123');
+        expect(buildTestPattern('My_Test-Case_v2')).toBe('My_Test-Case_v2');
+      });
+    });
+
+    // ===========================================
+    // SPACE HANDLING
+    // ===========================================
+    describe('space handling', () => {
+      it('should replace single spaces with dots', () => {
+        expect(buildTestPattern('test name')).toBe('test.name');
+        expect(buildTestPattern('should do something')).toBe('should.do.something');
+      });
+
+      it('should replace multiple consecutive spaces with multiple dots', () => {
+        expect(buildTestPattern('test  name')).toBe('test..name');
+        expect(buildTestPattern('test   name')).toBe('test...name');
+      });
+
+      it('should handle leading spaces', () => {
+        expect(buildTestPattern(' test')).toBe('.test');
+        expect(buildTestPattern('  test')).toBe('..test');
+      });
+
+      it('should handle trailing spaces', () => {
+        expect(buildTestPattern('test ')).toBe('test.');
+        expect(buildTestPattern('test  ')).toBe('test..');
+      });
+
+      it('should handle only spaces', () => {
+        expect(buildTestPattern(' ')).toBe('.');
+        expect(buildTestPattern('   ')).toBe('...');
+      });
+    });
+
+    // ===========================================
+    // REGEX SPECIAL CHARACTERS
+    // ===========================================
+    describe('regex special characters', () => {
+      it('should replace period with dot', () => {
+        expect(buildTestPattern('test.name')).toBe('test.name');
+        expect(buildTestPattern('v1.2.3')).toBe('v1.2.3');
+      });
+
+      it('should replace asterisk with dot', () => {
+        expect(buildTestPattern('test*')).toBe('test.');
+        expect(buildTestPattern('*test*')).toBe('.test.');
+      });
+
+      it('should replace plus with dot', () => {
+        expect(buildTestPattern('test+')).toBe('test.');
+        expect(buildTestPattern('a+b')).toBe('a.b');
+      });
+
+      it('should replace question mark with dot', () => {
+        expect(buildTestPattern('test?')).toBe('test.');
+        expect(buildTestPattern('is it working?')).toBe('is.it.working.');
+      });
+
+      it('should replace caret with dot', () => {
+        expect(buildTestPattern('^test')).toBe('.test');
+        expect(buildTestPattern('test^name')).toBe('test.name');
+      });
+
+      it('should replace dollar sign with dot', () => {
+        expect(buildTestPattern('test$')).toBe('test.');
+        expect(buildTestPattern('$test')).toBe('.test');
+        expect(buildTestPattern('$100')).toBe('.100');
+      });
+
+      it('should replace curly braces with dots', () => {
+        expect(buildTestPattern('test{1}')).toBe('test.1.');
+        expect(buildTestPattern('{a,b}')).toBe('.a.b.');
+        expect(buildTestPattern('test{1,3}')).toBe('test.1.3.');
+      });
+
+      it('should replace parentheses with dots', () => {
+        expect(buildTestPattern('test(name)')).toBe('test.name.');
+        expect(buildTestPattern('(test)')).toBe('.test.');
+        expect(buildTestPattern('func()')).toBe('func..');
+      });
+
+      it('should replace square brackets with dots', () => {
+        expect(buildTestPattern('test[0]')).toBe('test.0.');
+        expect(buildTestPattern('[test]')).toBe('.test.');
+        expect(buildTestPattern('array[index]')).toBe('array.index.');
+      });
+
+      it('should replace pipe with dot', () => {
+        expect(buildTestPattern('a|b')).toBe('a.b');
+        expect(buildTestPattern('test|name')).toBe('test.name');
+      });
+
+      it('should replace backslash with dot', () => {
+        expect(buildTestPattern('test\\name')).toBe('test.name');
+        expect(buildTestPattern('path\\to\\file')).toBe('path.to.file');
+      });
+    });
+
+    // ===========================================
+    // SHELL SPECIAL CHARACTERS
+    // ===========================================
+    describe('shell special characters', () => {
+      it('should replace backticks with dots', () => {
+        expect(buildTestPattern('test`command`')).toBe('test.command.');
+        expect(buildTestPattern('`whoami`')).toBe('.whoami.');
+      });
+
+      it('should replace single quotes with dots', () => {
+        expect(buildTestPattern("test's")).toBe('test.s');
+        expect(buildTestPattern("it's working")).toBe('it.s.working');
+        expect(buildTestPattern("'quoted'")).toBe('.quoted.');
+      });
+
+      it('should replace double quotes with dots', () => {
+        expect(buildTestPattern('test"name"')).toBe('test.name.');
+        expect(buildTestPattern('"quoted"')).toBe('.quoted.');
+      });
+
+      it('should replace semicolon with dot', () => {
+        expect(buildTestPattern('test;name')).toBe('test.name');
+        expect(buildTestPattern('cmd1;cmd2')).toBe('cmd1.cmd2');
+      });
+
+      it('should replace ampersand with dot', () => {
+        expect(buildTestPattern('test&name')).toBe('test.name');
+        expect(buildTestPattern('a&&b')).toBe('a..b');
+      });
+
+      it('should replace redirects with dots', () => {
+        expect(buildTestPattern('test>file')).toBe('test.file');
+        expect(buildTestPattern('test<file')).toBe('test.file');
+        expect(buildTestPattern('test>>file')).toBe('test..file');
+      });
+
+      it('should replace exclamation mark with dot', () => {
+        expect(buildTestPattern('test!')).toBe('test.');
+        expect(buildTestPattern('!important')).toBe('.important');
+      });
+
+      it('should replace tilde with dot', () => {
+        expect(buildTestPattern('~user')).toBe('.user');
+        expect(buildTestPattern('test~')).toBe('test.');
+      });
+
+      it('should replace hash with dot', () => {
+        expect(buildTestPattern('#comment')).toBe('.comment');
+        expect(buildTestPattern('test#1')).toBe('test.1');
+      });
+
+      it('should replace at sign with dot', () => {
+        expect(buildTestPattern('test@example')).toBe('test.example');
+        expect(buildTestPattern('@decorator')).toBe('.decorator');
+      });
+
+      it('should replace percent with dot', () => {
+        expect(buildTestPattern('100%')).toBe('100.');
+        expect(buildTestPattern('%s')).toBe('.s');
+      });
+
+      it('should replace equals with dot', () => {
+        expect(buildTestPattern('a=b')).toBe('a.b');
+        expect(buildTestPattern('test=value')).toBe('test.value');
+      });
+
+      it('should replace colon with dot', () => {
+        expect(buildTestPattern('test:name')).toBe('test.name');
+        expect(buildTestPattern('12:34:56')).toBe('12.34.56');
+      });
+
+      it('should replace forward slash with dot', () => {
+        expect(buildTestPattern('path/to/file')).toBe('path.to.file');
+        expect(buildTestPattern('a/b')).toBe('a.b');
+      });
+
+      it('should replace comma with dot', () => {
+        expect(buildTestPattern('a,b,c')).toBe('a.b.c');
+        expect(buildTestPattern('test, name')).toBe('test..name');
+      });
+    });
+
+    // ===========================================
+    // WHITESPACE CHARACTERS
+    // ===========================================
+    describe('whitespace characters', () => {
+      it('should replace tabs with dots', () => {
+        expect(buildTestPattern('test\tname')).toBe('test.name');
+        expect(buildTestPattern('\t\t')).toBe('..');
+      });
+
+      it('should replace newlines with dots', () => {
+        expect(buildTestPattern('test\nname')).toBe('test.name');
+        expect(buildTestPattern('line1\nline2')).toBe('line1.line2');
+      });
+
+      it('should replace carriage returns with dots', () => {
+        expect(buildTestPattern('test\rname')).toBe('test.name');
+        expect(buildTestPattern('test\r\nname')).toBe('test..name');
+      });
+
+      it('should replace mixed whitespace with dots', () => {
+        expect(buildTestPattern('test \t\n name')).toBe('test....name');
+      });
+    });
+
+    // ===========================================
+    // UNICODE CHARACTERS
+    // ===========================================
+    describe('unicode characters', () => {
+      it('should replace accented characters with dots', () => {
+        expect(buildTestPattern('café')).toBe('caf.');
+        expect(buildTestPattern('naïve')).toBe('na.ve');
+        expect(buildTestPattern('résumé')).toBe('r.sum.');
+      });
+
+      it('should replace emoji with dots (2 dots per emoji for surrogate pairs)', () => {
+        // Emoji like 🎉 are represented as surrogate pairs in UTF-16 (2 code units)
+        // The pattern needs to match the string length for regex to work properly
+        expect(buildTestPattern('test🎉')).toBe('test..');  // 🎉 = 2 code units
+        expect(buildTestPattern('👍test')).toBe('..test');  // 👍 = 2 code units
+        expect(buildTestPattern('🎉🎊')).toBe('....');       // 4 code units total
+      });
+
+      it('should replace Chinese characters with dots', () => {
+        expect(buildTestPattern('测试')).toBe('..');
+        expect(buildTestPattern('test测试')).toBe('test..');
+      });
+
+      it('should replace other unicode symbols with dots', () => {
+        expect(buildTestPattern('test™')).toBe('test.');
+        expect(buildTestPattern('©2024')).toBe('.2024');
+        expect(buildTestPattern('test→result')).toBe('test.result');
+      });
+    });
+
+    // ===========================================
+    // COMBINED EDGE CASES
+    // ===========================================
+    describe('combined edge cases', () => {
+      it('should handle realistic test names with spaces and parentheses', () => {
+        const pattern = buildTestPattern('should create a user (when valid)');
+        expect(pattern).toBe('should.create.a.user..when.valid.');
+      });
+
+      it('should handle test names with method calls', () => {
+        const pattern = buildTestPattern('Array.prototype.map() works');
+        expect(pattern).toBe('Array.prototype.map...works');
+      });
+
+      it('should handle test names with paths', () => {
+        const pattern = buildTestPattern('loads /api/users endpoint');
+        expect(pattern).toBe('loads..api.users.endpoint');
+      });
+
+      it('should handle test names with URLs', () => {
+        const pattern = buildTestPattern('fetches https://api.example.com/data');
+        expect(pattern).toBe('fetches.https...api.example.com.data');
+      });
+
+      it('should handle test names with JSON-like content', () => {
+        const pattern = buildTestPattern('parses {"key": "value"}');
+        expect(pattern).toBe('parses...key....value..');
+      });
+
+      it('should handle test names with shell-dangerous patterns', () => {
+        const pattern = buildTestPattern('test $(whoami) injection');
+        expect(pattern).toBe('test...whoami..injection');
+      });
+
+      it('should handle test names with backtick injection attempts', () => {
+        const pattern = buildTestPattern('test `rm -rf /` name');
+        expect(pattern).toBe('test..rm.-rf....name');
+      });
+
+      it('should handle test names with multiple special char types', () => {
+        // "test's [value] = $100 & 50%" character breakdown:
+        // test = safe, ' = ., s = safe, space = ., [ = ., value = safe, ] = .
+        // space = ., = = ., space = ., $ = ., 100 = safe, space = .
+        // & = ., space = ., 50 = safe, % = .
+        const pattern = buildTestPattern("test's [value] = $100 & 50%");
+        expect(pattern).toBe('test.s..value.....100...50.');
+      });
+
+      it('should handle very long test names', () => {
+        const longName = 'a'.repeat(1000);
+        const pattern = buildTestPattern(longName);
+        expect(pattern).toBe(longName);
+        expect(pattern.length).toBe(1000);
+      });
+
+      it('should handle test names that are all special characters', () => {
+        const pattern = buildTestPattern('!@#$%^&*()');
+        expect(pattern).toBe('..........');
+        expect(pattern.length).toBe(10);
+      });
+    });
+
+    // ===========================================
+    // PATTERN MATCHING VALIDATION
+    // ===========================================
+    describe('pattern matching validation', () => {
+      const testCases = [
+        'simple test',
+        'test with spaces',
+        'test.with.dots',
+        'test(with)parens',
+        'test[with]brackets',
+        "test's apostrophe",
+        'test "quotes"',
+        'test $variable',
+        'test `backticks`',
+        'test; semicolon',
+        'test | pipe',
+        'test & ampersand',
+        'test > redirect',
+        'test\ttab',
+        // Note: newlines are NOT included because regex '.' doesn't match \n
+        'exports TEST_CONFIG for use by other repos',
+        'should handle Array.prototype.map()',
+        'parses JSON {"key": "value"}',
+        'handles /api/v1/users/:id path',
+        'supports special chars: !@#$%^&*()',
+      ];
+
+      testCases.forEach(testName => {
+        it(`pattern for "${testName.slice(0, 40)}${testName.length > 40 ? '...' : ''}" should match original`, () => {
+          const pattern = buildTestPattern(testName);
+          const regex = new RegExp(pattern);
+          expect(regex.test(testName)).toBe(true);
+        });
+      });
+
+      it('should maintain same length as input for ASCII', () => {
+        const testCases = [
+          'simple',
+          'with spaces',
+          'special!@#chars',
+          'mixed_with-hyphens',
+        ];
+        testCases.forEach(testName => {
+          const pattern = buildTestPattern(testName);
+          expect(pattern.length).toBe(testName.length);
+        });
+      });
+
+      it('documents newline limitation: pattern does not match newlines', () => {
+        // This is a known limitation: regex '.' does not match newlines by default
+        // Test names with literal newlines are extremely rare in practice
+        const testName = 'test\nnewline';
+        const pattern = buildTestPattern(testName);
+        const regex = new RegExp(pattern);
+        // The pattern is correctly generated but won't match due to regex '.' limitation
+        expect(regex.test(testName)).toBe(false);
+        // But the pattern is still shell-safe
+        expect(pattern).toMatch(/^[a-zA-Z0-9_.\-]*$/);
+      });
+    });
+
+    // ===========================================
+    // PATTERN SPECIFICITY
+    // ===========================================
+    describe('pattern specificity', () => {
+      it('should not match significantly different names', () => {
+        const pattern = buildTestPattern('test one');
+        const regex = new RegExp(`^${pattern}$`);
+
+        // Should match original
+        expect(regex.test('test one')).toBe(true);
+        // Should match with any char in place of space
+        expect(regex.test('testXone')).toBe(true);
+
+        // Should NOT match different lengths
+        expect(regex.test('test')).toBe(false);
+        expect(regex.test('test one two')).toBe(false);
+        expect(regex.test('test onetwo')).toBe(false);
+      });
+
+      it('should differentiate tests by length', () => {
+        const pattern1 = buildTestPattern('test a');
+        const pattern2 = buildTestPattern('test ab');
+
+        expect(pattern1.length).not.toBe(pattern2.length);
+
+        const regex1 = new RegExp(`^${pattern1}$`);
+        const regex2 = new RegExp(`^${pattern2}$`);
+
+        expect(regex1.test('test a')).toBe(true);
+        expect(regex1.test('test ab')).toBe(false);
+
+        expect(regex2.test('test ab')).toBe(true);
+        expect(regex2.test('test a')).toBe(false);
+      });
+    });
+
+    // ===========================================
+    // REAL WORLD TEST NAMES
+    // ===========================================
+    describe('real world test names', () => {
+      // Test names that can be matched by the generated pattern
+      const matchableTestNames = [
+        'creates a snapshot',
+        'exports TEST_CONFIG for use by other repos',
+        'should handle errors gracefully',
+        'returns 404 for missing resource',
+        'validates email@example.com format',
+        "doesn't crash on null input",
+        'processes $100.00 correctly',
+        'handles [array] notation',
+        'supports {object} syntax',
+        'works with path/to/file',
+        'handles Unicode: café, naïve',
+        'Math.random() returns number',
+        'Array.prototype.map() transforms',
+        'handles async/await properly',
+        'GET /api/users returns 200',
+        'POST /api/users creates user',
+        'throws Error("message")',
+        'handles "quoted strings"',
+        "handles 'single quotes'",
+        'handles `template literals`',
+        'handles tabs\tin strings',
+      ];
+
+      matchableTestNames.forEach(testName => {
+        it(`should create valid pattern for: "${testName.slice(0, 50)}${testName.length > 50 ? '...' : ''}"`, () => {
+          const pattern = buildTestPattern(testName);
+
+          // Pattern should only contain safe chars and dots
+          expect(pattern).toMatch(/^[a-zA-Z0-9_.\-]*$/);
+
+          // Pattern should match original
+          const regex = new RegExp(pattern);
+          expect(regex.test(testName)).toBe(true);
+        });
+      });
+
+      it('should create shell-safe pattern even for unmatchable names (newlines)', () => {
+        // Newlines in test names are rare but the pattern should still be shell-safe
+        const testName = 'handles newlines\nin strings';
+        const pattern = buildTestPattern(testName);
+
+        // Pattern should only contain safe chars and dots
+        expect(pattern).toMatch(/^[a-zA-Z0-9_.\-]*$/);
+
+        // Note: won't match because '.' doesn't match newlines in regex
+        // This is a documented limitation for an extremely rare edge case
+      });
+    });
+
+    // ===========================================
+    // SHELL SAFETY VALIDATION
+    // ===========================================
+    describe('shell safety validation', () => {
+      it('should produce patterns containing only shell-safe characters', () => {
+        const dangerousNames = [
+          '$(whoami)',
+          '`rm -rf /`',
+          'test; echo hacked',
+          'test && echo hacked',
+          'test || echo hacked',
+          'test | cat /etc/passwd',
+          'test > /tmp/hacked',
+          'test < /etc/passwd',
+          '${PATH}',
+          '$(cat /etc/passwd)',
+          "test'; echo hacked; #",
+          'test"; echo hacked; #',
+          'test\necho hacked',
+          'test`echo hacked`',
+        ];
+
+        dangerousNames.forEach(name => {
+          const pattern = buildTestPattern(name);
+          // Pattern should only contain alphanumeric, underscore, hyphen, and dot
+          expect(pattern).toMatch(/^[a-zA-Z0-9_.\-]*$/);
+        });
+      });
+
+      it('should neutralize command injection attempts', () => {
+        const injectionAttempts = [
+          { input: '$(id)', expected: '..id.' },
+          { input: '`id`', expected: '.id.' },
+          { input: '; id', expected: '..id' },
+          { input: '| id', expected: '..id' },
+          { input: '&& id', expected: '...id' },
+          { input: '|| id', expected: '...id' },
+        ];
+
+        injectionAttempts.forEach(({ input, expected }) => {
+          expect(buildTestPattern(input)).toBe(expected);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Replace the brittle escapeRegExp/escapeShellArg combination with a new buildTestPattern function that handles all edge cases:

- Regex special characters: . * + ? ^ $ { } ( ) [ ] | \
- Shell special characters: space $ ` ' " ; | & < > ! ~ # @ % = : /
- Whitespace: tabs, carriage returns
- Unicode: accented chars, emoji (surrogate pairs), CJK characters

Strategy: Only use characters safe in both regex and shell contexts (a-z, A-Z, 0-9, underscore, hyphen). All other characters become '.' which matches any single character in regex and is harmless in shells.

This trades minor precision for maximum robustness - the pattern length matches the input length, so false matches are unlikely in practice since test names are typically unique.

Add comprehensive test suite (90+ new tests) covering:
- Basic cases and space handling
- All regex and shell special characters
- Unicode including emoji surrogate pairs
- Combined edge cases and real-world test names
- Pattern matching validation
- Shell safety validation for injection attempts

Known limitation: regex '.' doesn't match newlines, but test names with literal newlines are extremely rare in practice.